### PR TITLE
Fix page number range

### DIFF
--- a/src/main/kotlin/no/nav/pam/feed/ad/SearchClient.kt
+++ b/src/main/kotlin/no/nav/pam/feed/ad/SearchClient.kt
@@ -73,4 +73,4 @@ fun StatusPages.Configuration.feed() {
 }
 
 private val Parameters.size get() = (this["size"]?.toInt() ?: 20).coerceIn(1 .. 100 )
-private val Parameters.page get() = (this["page"]?.toInt() ?: 0).coerceIn(0 .. MAX_TOTAL_HITS / this.size)
+private val Parameters.page get() = (this["page"]?.toInt() ?: 0).coerceIn(0 until MAX_TOTAL_HITS / this.size)

--- a/src/test/kotlin/no/nav/pam/feed/ApiTest.kt
+++ b/src/test/kotlin/no/nav/pam/feed/ApiTest.kt
@@ -275,7 +275,7 @@ class ApiTest {
         }
 
         assertEquals(100, feed.pageSize)
-        assertEquals(50, feed.pageNumber)
+        assertEquals(49, feed.pageNumber)
         assertEquals(4, feed.totalPages)
         assertEquals(332, feed.totalElements)
         assertFalse(feed.first)


### PR DESCRIPTION
Hi, I was working on a code exercise when I came across this. Please excuse me if this is as intended.
 
It seems to me like there is a one off error in the coerced page number range. Resulting in 5000 + size results returned, with the two last pages both with `last: true`, but different contents.