### PR TITLE
Legger til støtte for å sende inn timezone offsets

### DIFF
--- a/src/main/kotlin/no/nav/pam/feed/ad/DateFilter.kt
+++ b/src/main/kotlin/no/nav/pam/feed/ad/DateFilter.kt
@@ -52,8 +52,8 @@ private const val wildcard = "*"
 private val startOfTime = LocalDateTime.now().minusYears(100)
 private val endOfTime = LocalDateTime.now().plusYears(100)
 private val dateTimeFormatter = DateTimeFormatterBuilder()
-        .appendOptional(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-        .appendOptional(DateTimeFormatter.ISO_LOCAL_DATE)
+        .appendOptional(DateTimeFormatter.ISO_DATE_TIME)
+        .appendOptional(DateTimeFormatter.ISO_DATE)
         .toFormatter()
 
 private fun String.isIntervalExpression(): Boolean = DATE_INTERVAL_SYNTAX.matcher(trim()).matches()

--- a/src/main/resources/swagger/api/public-feed-api.yaml
+++ b/src/main/resources/swagger/api/public-feed-api.yaml
@@ -41,6 +41,12 @@ paths:
              '[*,2019-06-01)' will match all ads published before June of 2019, while [2019-06-01,*) will match all ads
              published on or after June of 2019. Some literals are also supported, like 'today',
              'tomorrow' and 'yesterday' for dates. And 'now' indicating the current date and time.
+            
+             NB: Dates are by default parsed as UTC (+00.00). If you want to specify a timezone you can do 
+             so by providing the offset in the date or time with the format 'yyyy-MM-ddTZD' or 'yyyy-MM-ddTHH:mm:ssTZD'
+             where "TZD" is the time zone designator (Z or +hh:mm or -hh:mm). Examples for Europe/Oslo during Daylight 
+             saving time: '2019-06-12+02:00', '2019-06-12T23:00:00+02:00' 
+
           required: false
           schema:
             type: "string"

--- a/src/test/kotlin/no/nav/pam/feed/ad/DateFilterTest.kt
+++ b/src/test/kotlin/no/nav/pam/feed/ad/DateFilterTest.kt
@@ -88,6 +88,16 @@ class DateFilterTest {
     }
 
     @Test
+    fun dateIntervalDaysWithOffset() {
+        val dp = "[2018-01-01+02:00,2018-01-02+02:00]". parseAsDateFilter("somedate", true)
+        assertThat(dp).isNotNull()
+        assertThat(dp?.startInclusive).isTrue()
+        assertThat(dp?.endInclusive).isTrue()
+        assertThat(dp?.start(stringConverter).toString()).isEqualTo("2018-01-01+02:00")
+        assertThat(dp?.end(stringConverter).toString()).isEqualTo("2018-01-02+02:00")
+    }
+
+    @Test
     fun dateIntervalDays_startExclusive() {
         val dp = "(2018-01-01,2018-01-02]". parseAsDateFilter("somedate", true)
         assertThat(dp).isNotNull()
@@ -140,6 +150,16 @@ class DateFilterTest {
         assertThat(dp?.endInclusive).isTrue()
         assertThat(dp?.start(stringConverter).toString()).isEqualTo("2018-01-01T12:00:01")
         assertThat(dp?.end(stringConverter).toString()).isEqualTo("2018-01-02T12:00:00")
+    }
+
+    @Test
+    fun dateIntervalWithTimesAndOffset() {
+        val dp = "[2018-01-01T12:00:01+02:00,2018-01-02T12:00+02:00]". parseAsDateFilter("somedate", true)
+        assertThat(dp).isNotNull()
+        assertThat(dp?.startInclusive).isTrue()
+        assertThat(dp?.endInclusive).isTrue()
+        assertThat(dp?.start(stringConverter).toString()).isEqualTo("2018-01-01T12:00:01+02:00")
+        assertThat(dp?.end(stringConverter).toString()).isEqualTo("2018-01-02T12:00:00+02:00")
     }
 
     @Test


### PR DESCRIPTION
Endrer `dateTimeFormatter` fra å bruke `ISO_LOCAL_DATE_TIME` og `ISO_LOCAL_DATE` (som ikke støtter offsets) til å bruke `ISO_DATE_TIME` og `ISO_DATE` som gjør det dersom de eksisterer.