### PR TITLE
Oppdaterte lenker til vilkår for bruk

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ As a public agency responsible for getting people into work, NAV keeps a job ads
 Publishing data about available jobs for the Norwegian population and employers is found in this API
 
 ## Terms of service
-Terms of service for the use of the feed API can be found here: https://arbeidsplassen.nav.no/vilkar-api
+Terms of service for the use of the feed API can be found here: https://arbeidsplassen.nav.no/vilkar-api-gammel
 
 ## Authentication
 

--- a/src/main/resources/swagger/api/public-feed-api.yaml
+++ b/src/main/resources/swagger/api/public-feed-api.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: "NAV ads public API"
   description: "This API provides published data about available jobs in Norway and information on employers\n For more documentation and the public API-key, please visit our Github page [PAM Public Feed](https://github.com/navikt/pam-public-feed/)"
-  termsOfService: "https://arbeidsplassen.nav.no/publicfeed/swagger/"
+  termsOfService: "https://arbeidsplassen.nav.no/vilkar-api-gammel"
   contact:
     email: "plattform.for.arbeidsmarkedet@nav.no"
   version: '1'


### PR DESCRIPTION
Ref tråden i [slack](https://nav-it.slack.com/archives/C02UJQ9LY10/p1713782330804669) ang at det for public-feed er vilkårene beskrevet på https://arbeidsplassen.nav.no/vilkar-api-gammel som gjelder.

NB! Legg merke til at det fra før var de "nye vilkårene", https://arbeidsplassen.nav.no/vilkar-api-gammel, som var brukt i readme-en her.