### PR TITLE
Oppdaterer Kotlin til 2.0.21, JVMen til 21 og Docker baseimage til Temurin

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -18,7 +18,8 @@ jobs:
       security-events: write
       id-token: write
     with:
-      JAVA_VERSION: 11
+      JAVA_VERSION: 21
+      JAVA_DISTRIBUTION: 'temurin'
       BUILD_CACHE: maven
       SKIP_DRAFT_RELEASE: ${{ github.ref_name != 'master' }}
     secrets:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM navikt/java:11
+FROM ghcr.io/navikt/baseimages/temurin:21
 COPY target/pam-public-feed-*-jar-with-dependencies.jar /app/app.jar
 ENV JAVA_OPTS="-Xms256m -Xmx1024m"
 EXPOSE 9021

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <main.class>no.nav.pam.feed.BootstrapKt</main.class>
-        <kotlin.version>1.6.10</kotlin.version>
+        <kotlin.version>2.0.21</kotlin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <ktor.version>1.6.7</ktor.version>
         <assertj.version>3.12.0</assertj.version>
@@ -186,7 +186,7 @@
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <version>${kotlin.version}</version>
                 <configuration>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>21</jvmTarget>
                 </configuration>
                 <executions>
                     <execution>
@@ -271,4 +271,3 @@
         </snapshotRepository>
     </distributionManagement>
 </project>
-


### PR DESCRIPTION
Av de 9 sårbarhetene som er listet som Critical her:
https://console.nav.cloud.nais.io/team/teampam/prod-gcp/app/pam-public-feed/image
Så er 8 av dem fra baseimaget, og bare 1 fra koden. Jeg starter derfor med å oppdatere baseimaget til temurin, og i den samme slengen er det da naturlig å ta med JVMen til 21. Jeg tok også med Kotlin, da den versjonen som var i bruk var så gammel at IntelliJ klagde..